### PR TITLE
Adds support for Server Passwords & SSL connections

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -20,8 +20,8 @@ To use summer, create a file like this:
 
     Bot.new("localhost")
 
-Running it will make your bot attempt to connect to the server on localhost. For those of you who do not have an IRC server running locally, I would suggest trying irc.freenode.net instead. 
-    
+Running it will make your bot attempt to connect to the server on localhost. For those of you who do not have an IRC server running locally, I would suggest trying irc.freenode.net instead.
+
 ## Configuration
 
 In the same directory create a directory called _config_ and in that put _summer.yml_ which can have the following keys:
@@ -31,6 +31,8 @@ In the same directory create a directory called _config_ and in that put _summer
 * channels: Channels to join on startup.
 * auto_rejoin: Set this to true if you want the bot to re-join any channel it's kicked from.
 * nickserv_password: Password to send to nickserv after connection but before joining any channels
+* server_password: Password to authenticate with a server the irc server requires it.
+* use_ssl: `true` or `false` defaults to `false`. If an IRC server requires SSL, it will establish the connection
 
 ## `did_start_up`
 

--- a/lib/summer.rb
+++ b/lib/summer.rb
@@ -1,4 +1,5 @@
 require 'socket'
+require 'openssl'
 require 'fileutils'
 require 'yaml'
 require 'active_support/hash_with_indifferent_access'
@@ -53,7 +54,9 @@ module Summer
 
     def connect!
       @connection = TCPSocket.open(server, port)
+      @connection = OpenSSL::SSL::SSLSocket.new(@connection).connect if config[:use_ssl]
       response("USER #{config[:nick]} #{config[:nick]} #{config[:nick]} #{config[:nick]}")
+      response("PASS #{config[:server_password]}") if config[:server_password]
       response("NICK #{config[:nick]}")
     end
 


### PR DESCRIPTION
Server passwords & ssl connection support added via config variables.

I needed this to be able to connect to a private channel, that required SSL. I our case, this was enabling the Slack IRC support, so i could make my IRC bots work with slack even ;)