### PR TITLE
Makes irc server configurable, updates readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -26,13 +26,14 @@ Running it will make your bot attempt to connect to the server on localhost. For
 
 In the same directory create a directory called _config_ and in that put _summer.yml_ which can have the following keys:
 
-* nick: The nickname of the bot.
-* channel: A channel to join on startup.
-* channels: Channels to join on startup.
-* auto_rejoin: Set this to true if you want the bot to re-join any channel it's kicked from.
-* nickserv_password: Password to send to nickserv after connection but before joining any channels
-* server_password: Password to authenticate with a server the irc server requires it.
+* server: The IRC server url the bot will connect to. Can also be passed in to the initializer as the first argument.
 * use_ssl: `true` or `false` defaults to `false`. If an IRC server requires SSL, it will establish the connection
+* nick: The nickname of the bot.
+* server_password: Password to authenticate with a server, if the irc server requires it.
+* nickserv_password: Password to send to nickserv after connection but before joining any channels
+* channel: A channel to join on startup.
+* channels: Channels to join on startup. e.g. `['RubyOnRails', 'ruby']`
+* auto_rejoin: Set this to `true` if you want the bot to re-join any channel it's kicked from.
 
 ## `did_start_up`
 

--- a/lib/summer.rb
+++ b/lib/summer.rb
@@ -13,7 +13,7 @@ module Summer
   class Connection
     include Handlers
     attr_accessor :connection, :ready, :started, :config, :server, :port
-    def initialize(server, port=6667, dry=false)
+    def initialize(server=nil, port=6667, dry=false)
       @ready = false
       @started = false
 
@@ -33,9 +33,12 @@ module Summer
       end
 
       load_config
+      @server = config[:server] if server.nil?
+
       File.open(pid_file, "w+") do |f|
         f.write Process.pid
       end
+
       connect!
 
       unless dry


### PR DESCRIPTION
@radar, what do you think about this? 

It seems everything else was configurable, so made sense to make the server configurable as well. By setting the `server=nil` in the initializer, it could still be overriden by passing the server into initializer  `Bot.new('irc.freenode.net')`, and not break any existing bots out there.

Updated some verbiage & ordering of configurations in readme